### PR TITLE
Change name of ContentType to "Content-Type"

### DIFF
--- a/src/header/content_type.rs
+++ b/src/header/content_type.rs
@@ -24,7 +24,7 @@ pub struct ContentType(Mime);
 impl Header for ContentType {
 	#[inline(always)]
 	fn name() -> &'static str {
-		"Content-Length"
+		"Content-Type"
 	}
 
 	#[inline]


### PR DESCRIPTION
How did that ever work?